### PR TITLE
Add Elementary Controls

### DIFF
--- a/cowtown2023/src/main/java/com/team2357/frc2023/Constants.java
+++ b/cowtown2023/src/main/java/com/team2357/frc2023/Constants.java
@@ -163,6 +163,7 @@ public final class Constants {
 
         public static final double TIME_TO_COAST_SECONDS = 5000;
 
+        public static final double DEMO_MODE_DRIVE_REDUCTION = 1/2;
     }
 
     public static final class CONTROLLER {

--- a/cowtown2023/src/main/java/com/team2357/frc2023/commands/DefaultDriveCommand.java
+++ b/cowtown2023/src/main/java/com/team2357/frc2023/commands/DefaultDriveCommand.java
@@ -33,6 +33,6 @@ public class DefaultDriveCommand extends CommandBase {
 
     @Override
     public void end(boolean interrupted) {
-        m_swerve.drive(new Translation2d(), 0, RobotState.isFieldRelative(), false);
+        m_swerve.drive(new Translation2d(), 0, true, false);
     }
 }

--- a/cowtown2023/src/main/java/com/team2357/frc2023/commands/auto/util/MoveForwardCommand.java
+++ b/cowtown2023/src/main/java/com/team2357/frc2023/commands/auto/util/MoveForwardCommand.java
@@ -1,7 +1,6 @@
 package com.team2357.frc2023.commands.auto.util;
 
 import com.team2357.frc2023.Robot;
-import com.team2357.frc2023.state.RobotState;
 
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.CommandBase;
@@ -26,6 +25,6 @@ public class MoveForwardCommand extends CommandBase {
 
     @Override
     public void end(boolean interrupted) {
-        Robot.drive.drive(new Translation2d(), 0, RobotState.isFieldRelative(), false);
+        Robot.drive.drive(new Translation2d(), 0, true, false);
     }
 }

--- a/cowtown2023/src/main/java/com/team2357/frc2023/controls/OperatorControls.java
+++ b/cowtown2023/src/main/java/com/team2357/frc2023/controls/OperatorControls.java
@@ -7,6 +7,7 @@ import com.team2357.frc2023.commands.human.panic.IntakeSlideAxisCommand;
 import com.team2357.frc2023.commands.human.panic.ShooterAxisCommand;
 import com.team2357.frc2023.commands.intakeRoller.IntakeRollerPickupCubeCommand;
 import com.team2357.frc2023.commands.intakeRoller.IntakeRollerRollCubeCommand;
+import com.team2357.frc2023.state.RobotState;
 import com.team2357.lib.triggers.AxisThresholdTrigger;
 import com.team2357.lib.util.Utility;
 import com.team2357.lib.util.XboxRaw;
@@ -178,6 +179,10 @@ public class OperatorControls implements RumbleInterface {
         upDPadOnly.whileTrue(new ShooterAxisCommand(rightTriggerAxis));
 
         downDPadOnly.whileTrue(new IntakeRollerAxisCommand(topIntakeRollerAxis, bottomIntakeRollerAxis));
+
+        m_startButton.onTrue(new InstantCommand(() -> {
+            RobotState.toggleDriveControlState();
+        }));
     
     }
 

--- a/cowtown2023/src/main/java/com/team2357/frc2023/controls/SwerveDriveControls.java
+++ b/cowtown2023/src/main/java/com/team2357/frc2023/controls/SwerveDriveControls.java
@@ -1,5 +1,6 @@
 package com.team2357.frc2023.controls;
 
+import com.team2357.frc2023.Constants;
 import com.team2357.frc2023.Robot;
 import com.team2357.frc2023.commands.IntakeDeployCommandGroup;
 import com.team2357.frc2023.commands.IntakeStowCommandGroup;
@@ -7,6 +8,7 @@ import com.team2357.frc2023.commands.shooter.ShootCubeCommandGroup;
 import com.team2357.frc2023.commands.shooter.ShootCubeCommandGroup.SHOOTER_RPMS;
 import com.team2357.frc2023.commands.shooter.ShooterIntakeCommandGroup;
 import com.team2357.frc2023.commands.shooter.ShooterStopMotorsCommand;
+import com.team2357.frc2023.state.RobotState;
 import com.team2357.lib.triggers.AxisThresholdTrigger;
 import com.team2357.lib.util.XboxRaw;
 
@@ -103,8 +105,15 @@ public class SwerveDriveControls implements RumbleInterface {
     public double modifyAxis(double value) {
         value = deadband(value, m_deadband);
         value = Math.copySign(value * value, value);
+        switch (RobotState.getDriveControlState()) {
+            case COMPETITION_MODE:
+                return value;
+            case DEMO_MODE:
+                return value * Constants.SWERVE.DEMO_MODE_DRIVE_REDUCTION;
+        }
         return value;
     }
+
 
     public void setRumble(RumbleType type, double intensity) {
         m_controller.setRumble(type, intensity);

--- a/cowtown2023/src/main/java/com/team2357/frc2023/state/RobotState.java
+++ b/cowtown2023/src/main/java/com/team2357/frc2023/state/RobotState.java
@@ -8,8 +8,8 @@ public class RobotState {
     private static final RobotState s_instance = new RobotState();
 
     public static enum DriveControlState {
-        FIELD_RELATIVE, // Manual control of the robot is field relative
-        ROBOT_CENTRIC // Manual control of the robot is robot centric
+        COMPETITION_MODE,
+        DEMO_MODE
     }
 
     public static Alliance getAlliance() {
@@ -28,12 +28,19 @@ public class RobotState {
         s_instance.setAlliance(alliance);
     }
 
-    public static boolean isFieldRelative() {
-        return s_instance.m_currentDriveControlState == DriveControlState.FIELD_RELATIVE;
-    }
-
     public static DriveControlState getDriveControlState() {
         return s_instance.m_currentDriveControlState;
+    }
+
+    public static void toggleDriveControlState() {
+        switch (getDriveControlState()) {
+            case COMPETITION_MODE:
+                setDriveControlState(DriveControlState.DEMO_MODE);
+                break;
+            case DEMO_MODE:
+                setDriveControlState(DriveControlState.COMPETITION_MODE);
+                break;
+        }
     }
 
     public static void setDriveControlState(DriveControlState driveControlState) {
@@ -46,7 +53,7 @@ public class RobotState {
 
     private RobotState() {
         m_alliance = Alliance.Invalid;
-        m_currentDriveControlState = DriveControlState.FIELD_RELATIVE;
+        m_currentDriveControlState = DriveControlState.COMPETITION_MODE;
         m_zeroed = false;
     }
 

--- a/cowtown2023/src/main/java/com/team2357/frc2023/subsystems/IntakeSlideSubsystem.java
+++ b/cowtown2023/src/main/java/com/team2357/frc2023/subsystems/IntakeSlideSubsystem.java
@@ -7,6 +7,7 @@ import com.revrobotics.SparkMaxPIDController;
 import com.revrobotics.CANSparkMax.ControlType;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.team2357.frc2023.Constants;
+import com.team2357.frc2023.state.RobotState;
 import com.team2357.lib.subsystems.ClosedLoopSubsystem;
 import com.team2357.lib.util.Utility;
 
@@ -60,9 +61,15 @@ public class IntakeSlideSubsystem extends ClosedLoopSubsystem {
     }
 
     public void setSlideRotations(double rotations) {
-        setClosedLoopEnabled(true);
-        m_targetRotations = rotations;
-        m_slidePIDController.setReference(m_targetRotations, ControlType.kSmartMotion);
+        switch (RobotState.getDriveControlState()) {
+            case COMPETITION_MODE: {
+                setClosedLoopEnabled(true);
+                m_targetRotations = rotations;
+                m_slidePIDController.setReference(m_targetRotations, ControlType.kSmartMotion);
+            }
+            default:
+                return;
+        }
     }
 
     public void setSlideAxisSpeed(double axisSpeed) {


### PR DESCRIPTION
Making controls to let untrained drivers drive the cube bot. IntakeSlide is disabled to prevent what happened at Cowtown since we are still using 3d printed motor mounts.